### PR TITLE
EDB-12 When a town is on the border of a region images break

### DIFF
--- a/dynmap_bot_core/engine/coordinate.py
+++ b/dynmap_bot_core/engine/coordinate.py
@@ -2,6 +2,7 @@ __all__ = ["Coordinate"]
 import math
 from abc import ABC
 
+
 class Coordinate(ABC):
     def __init__(self, x, y, z):
         self.x: int = x
@@ -16,6 +17,9 @@ class Coordinate(ABC):
     def __hash__(self):
         return hash((self.x, self.y, self.z))
 
+    def __repr__(self):
+        return repr(f"{self.x}, {self.y}, {self.z}")
+
     def get_world_coordinate(self) -> "Coordinate":
         return Coordinate(math.floor(self.x / 16), self.y, math.floor(self.z / 16))
 
@@ -24,5 +28,3 @@ class Coordinate(ABC):
 
     def get_region_coordinate(self) -> "Coordinate":
         return Coordinate(math.floor(self.x / 512), self.y, math.floor(self.z / 512))
-
-

--- a/dynmap_bot_core/engine/map.py
+++ b/dynmap_bot_core/engine/map.py
@@ -1,6 +1,7 @@
 __all__ = ["Map"]
 from dynmap_bot_core.engine.coordinate import Coordinate
 from dynmap_bot_core.engine.town import Town
+from dynmap_bot_core.engine.chunk import Chunk
 from shapely.geometry import Polygon
 
 
@@ -52,7 +53,7 @@ class Map:
         """
         offset_x = self.get_polygon_top_left_corner().x
         offset_z = self.get_polygon_top_left_corner().z
-        return self.offset_towns(-offset_x, 0, -offset_z)
+        return self.offset_towns(-offset_x - Chunk.SIZE, 0, -offset_z - Chunk.SIZE)
 
     def get_town_polygons(self) -> list[Polygon]:
         """
@@ -70,8 +71,8 @@ class Map:
         Gets the maps offset from the nearest region border
         """
         minimum_coordinate: Coordinate = self.get_polygon_top_left_corner()
-        x_offset: int = minimum_coordinate.x % 512
-        z_offset: int = minimum_coordinate.z % 512
+        x_offset: int = (minimum_coordinate.x + Chunk.SIZE) % 512
+        z_offset: int = (minimum_coordinate.z + Chunk.SIZE) % 512
         offset: list[int] = [x_offset, z_offset]
         return offset
 

--- a/dynmap_bot_core/engine/misc.py
+++ b/dynmap_bot_core/engine/misc.py
@@ -8,13 +8,14 @@ from dynmap_bot_core import download as dl
 from dynmap_bot_core.images import image as img
 from PIL import Image
 
-def unpack_town_coordinates(town_json: dict) -> list[list[int,int]]:
+
+def unpack_town_coordinates(town_json: dict) -> list[list[int, int]]:
     """
     Given a dictionary of a town object, return all coordinates
     :param town_json: Town object as a dictionary.
     :return: list of ints for all coordinates.
     """
-    coordinates: list[list[int,int]] = [town_json["coordinates"]["townBlocks"]]
+    coordinates: list[list[int, int]] = [town_json["coordinates"]["townBlocks"]]
     return coordinates
 
 
@@ -26,7 +27,9 @@ def build_town(town_name: str) -> Town:
     :param town_name:
     :return:
     """
-    town: list[list[int,int]] = unpack_town_coordinates(common.download_town(town_name))
+    town: list[list[int, int]] = unpack_town_coordinates(
+        common.download_town(town_name)
+    )
     return Town([Chunk(x, 0, z) for x, z in town[0]])
 
 
@@ -36,7 +39,8 @@ def build_map(town_names: list[str]) -> Map:
     :param town_names:
     :return:
     """
-    return Map([build_town(town) for town in town_names])
+    towns = [build_town(town) for town in town_names]
+    return Map(towns)
 
 
 def build_image_with_map(map_obj: Map) -> Image:
@@ -47,13 +51,10 @@ def build_image_with_map(map_obj: Map) -> Image:
     :return: an Image object with the polygon overlayed ontop of the background
     """
     map_regions: list[Coordinate] = list(map_obj.get_regions())
-
     normalised_map = map_obj.get_normalised_map()
     offset = map_obj.get_region_offset()
     map_multipolygon: Map = normalised_map.offset_towns(offset[0], 0, offset[1])
-
     image_data = dl.map_images_as_dict(map_regions)
-
     image: Image = img.make_image_collage(image_data)
 
     for map_polygon in map_multipolygon.get_town_polygons():

--- a/dynmap_bot_tests/images.py
+++ b/dynmap_bot_tests/images.py
@@ -22,53 +22,9 @@ def test_coordinates_with_map():
     )
     image.resize_image(cropped_image).show()
 
-
-def test_coordinates_with_map_nw():
-    town_names: list[str] = ["Marseilles", "Chicago"]
-    map_obj: Map = misc.build_map(town_names)
-
-    normalised_map: Map = map_obj.get_normalised_map()
-    offset: list[int] = map_obj.get_region_offset()
-    offset_map: Map = normalised_map.offset_towns(offset[0], 0, offset[1])
-
-    image_obj: Image = misc.build_image_with_map(map_obj)
-    cropped_image: Image = image.crop_image(
-        image=image_obj,
-        top_left=offset_map.get_polygon_top_left_corner(),
-        bottom_right=offset_map.get_polygon_bottom_right_corner(),
-    )
-    image.resize_image(cropped_image).show()
-
-
-def test_coordinates_with_france():
-    town_names: list[str] = ["Limerick", "Paris", "Brittany"]
-    map_obj: Map = misc.build_map(town_names)
-
-    normalised_map: Map = map_obj.get_normalised_map()
-    offset: list[int] = map_obj.get_region_offset()
-    offset_map: Map = normalised_map.offset_towns(offset[0], 0, offset[1])
-
-    image_obj: Image = misc.build_image_with_map(map_obj)
-    cropped_image: Image = image.crop_image(
-        image=image_obj,
-        top_left=offset_map.get_polygon_top_left_corner(),
-        bottom_right=offset_map.get_polygon_bottom_right_corner(),
-    )
-    image.resize_image(cropped_image).show()
-
-
 def test_coordinates_with_limerick():
     town_names: list[str] = ["Limerick"]
     map_obj: Map = misc.build_map(town_names)
-    image_obj: Image = misc.build_image_with_map(map_obj)
-
-    image.resize_image(image_obj).show()
-
-
-def test_coordinates_with_new_france():
-    town_names: list[str] = ["Paris", "Brittany"]
-    map_obj: Map = misc.build_map(town_names)
-
     image_obj: Image = misc.build_image_with_map(map_obj)
 
     image.resize_image(image_obj).show()

--- a/dynmap_bot_tests/images.py
+++ b/dynmap_bot_tests/images.py
@@ -3,10 +3,11 @@ from dynmap_bot_core.engine.map import Map
 from dynmap_bot_core.images import image
 from PIL import Image
 
+
 # TODO mock these with static towns and/or json data.
 # This currently just acts an an entry point to manually test.
 def test_coordinates_with_map():
-    town_names: list[str] = ["Sanctuary","Gulf_Of_Guinea"]
+    town_names: list[str] = ["Sanctuary", "Gulf_Of_Guinea"]
     map_obj: Map = misc.build_map(town_names)
 
     normalised_map: Map = map_obj.get_normalised_map()
@@ -20,3 +21,54 @@ def test_coordinates_with_map():
         bottom_right=offset_map.get_polygon_bottom_right_corner(),
     )
     image.resize_image(cropped_image).show()
+
+
+def test_coordinates_with_map_nw():
+    town_names: list[str] = ["Marseilles", "Chicago"]
+    map_obj: Map = misc.build_map(town_names)
+
+    normalised_map: Map = map_obj.get_normalised_map()
+    offset: list[int] = map_obj.get_region_offset()
+    offset_map: Map = normalised_map.offset_towns(offset[0], 0, offset[1])
+
+    image_obj: Image = misc.build_image_with_map(map_obj)
+    cropped_image: Image = image.crop_image(
+        image=image_obj,
+        top_left=offset_map.get_polygon_top_left_corner(),
+        bottom_right=offset_map.get_polygon_bottom_right_corner(),
+    )
+    image.resize_image(cropped_image).show()
+
+
+def test_coordinates_with_france():
+    town_names: list[str] = ["Limerick", "Paris", "Brittany"]
+    map_obj: Map = misc.build_map(town_names)
+
+    normalised_map: Map = map_obj.get_normalised_map()
+    offset: list[int] = map_obj.get_region_offset()
+    offset_map: Map = normalised_map.offset_towns(offset[0], 0, offset[1])
+
+    image_obj: Image = misc.build_image_with_map(map_obj)
+    cropped_image: Image = image.crop_image(
+        image=image_obj,
+        top_left=offset_map.get_polygon_top_left_corner(),
+        bottom_right=offset_map.get_polygon_bottom_right_corner(),
+    )
+    image.resize_image(cropped_image).show()
+
+
+def test_coordinates_with_limerick():
+    town_names: list[str] = ["Limerick"]
+    map_obj: Map = misc.build_map(town_names)
+    image_obj: Image = misc.build_image_with_map(map_obj)
+
+    image.resize_image(image_obj).show()
+
+
+def test_coordinates_with_new_france():
+    town_names: list[str] = ["Paris", "Brittany"]
+    map_obj: Map = misc.build_map(town_names)
+
+    image_obj: Image = misc.build_image_with_map(map_obj)
+
+    image.resize_image(image_obj).show()


### PR DESCRIPTION
# Description
A region is a 512x512 area of a Minecraft map. 
When a towns top left corner borders on a region border, the image and town can be offset incorrectly such that the the image is blank. 

# Changes
This pr changes the get_region_offset() implementation. 
The previous logic did not account for the size of the chunk, and therefore if a town was on the of a region it was considered to be 1 chunk into the next region, and throwing off the offset by -496.

# Manual Testing
A test for the current location of Limerick has been added. Once mocked testing is implemented, this will be moved to a deterministic automated test. 