### PR TITLE
Edb 17 Adjust the normalised offset

### DIFF
--- a/dynmap_bot_core/engine/map.py
+++ b/dynmap_bot_core/engine/map.py
@@ -53,7 +53,7 @@ class Map:
         """
         offset_x = self.get_polygon_top_left_corner().x
         offset_z = self.get_polygon_top_left_corner().z
-        return self.offset_towns(-offset_x - Chunk.SIZE, 0, -offset_z - Chunk.SIZE)
+        return self.offset_towns(-offset_x, 0, -offset_z)
 
     def get_town_polygons(self) -> list[Polygon]:
         """

--- a/dynmap_bot_core/engine/map.py
+++ b/dynmap_bot_core/engine/map.py
@@ -52,7 +52,7 @@ class Map:
         """
         offset_x = self.get_polygon_top_left_corner().x
         offset_z = self.get_polygon_top_left_corner().z
-        self.offset_towns(-offset_x - Chunk.SIZE, 0, -offset_z - Chunk.SIZE)
+        return self.offset_towns(-offset_x, 0, -offset_z)
 
     def get_town_polygons(self) -> list[Polygon]:
         """

--- a/dynmap_bot_core/engine/misc.py
+++ b/dynmap_bot_core/engine/misc.py
@@ -66,12 +66,11 @@ def build_image_with_map(map_obj: Map) -> Image:
     offset = map_obj.get_region_offset()
     map_regions: list[Coordinate] = list(map_obj.get_regions())
     map_obj.normalise()
+    map_obj.offset_towns(-Chunk.SIZE, 0, -Chunk.SIZE)
     map_obj.offset_towns(offset[0], 0, offset[1])
     image_data = dl.map_images_as_dict(map_regions)
     image: Image = img.make_image_collage(image_data)
 
     image = img.make_grids_on_collage(map_obj.get_town_polygons(), image)
-    # for map_polygon in map_obj.get_town_polygons():
-    #     image = img.make_grid_on_collage(map_polygon, image)
 
     return image

--- a/dynmap_bot_core/images/image.py
+++ b/dynmap_bot_core/images/image.py
@@ -111,6 +111,8 @@ def crop_map_and_image(mcmap: Map, imgobj: Image) -> Image:
     TODO refactor this so chunk.SIZE can be imported without a circular import, and Coordinate can be used
     """
     normalised_map: Map = mcmap.get_normalised_map()
+    normalised_map: Map = normalised_map.offset_towns(-16, 0, -16)
+
     offset: list[int] = mcmap.get_region_offset()
     offset_map: Map = normalised_map.offset_towns(offset[0], 0, offset[1])
     return crop_image(

--- a/dynmap_bot_core/images/image.py
+++ b/dynmap_bot_core/images/image.py
@@ -117,6 +117,8 @@ def crop_map_and_image(mcmap: Map, imgobj: Image) -> Image:
     """
     offset: list[int] = mcmap.get_region_offset()
     mcmap.normalise()
+    mcmap.offset_towns(-16, 0, -16)
+
     mcmap.offset_towns(offset[0], 0, offset[1])
     return crop_image(
         image=imgobj,

--- a/dynmap_bot_tests/test_coordinate.py
+++ b/dynmap_bot_tests/test_coordinate.py
@@ -119,9 +119,9 @@ class TestMapMethods:
 
         assert isinstance(result, list)
 
-    def test_normalised_polygons_minimum_is_offset_by_chunk(
+    def test_normalised_polygons_minimum_is_zero(
         self,
-    ) -> None:  # todo change this to zero and offset in separate step
+    ) -> None:
         coord = Chunk(10, 0, 10)
         town = Town([coord])
         _map = Map([town])
@@ -131,8 +131,8 @@ class TestMapMethods:
         x = result.x
         z = result.z
 
-        assert x == -16
-        assert z == -16
+        assert x == 0
+        assert z == 0
 
     def test_regions_are_accurate(self) -> None:
         expected = Coordinate(0, 0, 0)


### PR DESCRIPTION
# Description

This PR changes the normalized offset method to have a minimum x and z coordinate of 0,0 for clarity. This was previously was -16,-16. For images having the addition border of 16px on each side, the map/nation should be offset by -16,-16 to mimic the previous behaviour. 

Fixes #17 